### PR TITLE
Use default method for params

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -12,11 +12,13 @@ module CanCan
     end
 
     def initialize(controller, *args)
-      @params_method = args.last[:attributes] if args.last.respond_to?(:[])
       @controller = controller
       @params = controller.params
       @options = args.extract_options!
       @name = args.first
+
+      @params_method = args.last[:attributes] if args.last.class == Hash
+      @params_method ||= "#{name}_params"
       raise CanCan::ImplementationRemoved, "The :nested option is no longer supported, instead use :through with separate load/authorize call." if @options[:nested]
       raise CanCan::ImplementationRemoved, "The :name option is no longer supported, instead pass the name as the first argument." if @options[:name]
       raise CanCan::ImplementationRemoved, "The :resource option has been renamed back to :class, use false if no class." if @options[:resource]

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -497,5 +497,13 @@ describe CanCan::ControllerResource do
       resource = CanCan::ControllerResource.new(@controller, {:attributes => :attributes_method})
       resource.send("resource_params_by_namespaced_name").should eq(sanitized)
     end
+
+    it "should use a default attributes method based on the model name" do
+      @params.merge!(:controller => "project", :action => "create")
+      sanitized = {:first => 1, :second => 2}
+      stub(@controller).post_params {sanitized}
+      resource = CanCan::ControllerResource.new(@controller, {:name => 'post'})
+      resource.send("resource_params_by_namespaced_name").should eq(sanitized)
+    end
   end
 end


### PR DESCRIPTION
Uses `post_params` for `PostController` or when the `name` option is explicitly passed as `post`.
